### PR TITLE
Add Option to use OSS variants of packages.

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,7 +16,7 @@ jobs:
       # max-parallel: 4
       matrix:
         distro: [centos7, debian10]
-        scenario: [default]
+        scenario: [default, oss]
 
     steps:
       - name: Check out code

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Role Variables
 --------------
 
 *elastic_release*: Major release version of Elastic stack to configure. (default: `7`)
+*elastic_variant*: Variant of the stack to install. Valid values: `elastic` or `oss`. (default: `elastic`)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for elastic-repos
 elastic_release: 7
+elastic_variant: elastic

--- a/molecule/oss/INSTALL.rst
+++ b/molecule/oss/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/oss/converge.yml
+++ b/molecule/oss/converge.yml
@@ -1,0 +1,11 @@
+---
+# The workaround for arbitrarily named role directory is important because the git repo has one name and the role within it another
+# Found at: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
+- name: Converge
+  hosts: all
+  vars:
+    elastic_variant: oss
+  tasks:
+    - name: "Include Elastic Repos"
+      include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/oss/molecule.yml
+++ b/molecule/oss/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: elastic-repos-default-oss
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .

--- a/molecule/oss/prepare.yml
+++ b/molecule/oss/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install requirements for Debian
+      package:
+        name:
+        - gpg
+        - apt-transport-https
+      when: ansible_os_family == "Debian"

--- a/molecule/oss/verify.yml
+++ b/molecule/oss/verify.yml
@@ -6,4 +6,4 @@
   tasks:
   - name: Install Kibana
     package:
-      name: kibana
+      name: kibana-oss

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,10 +1,17 @@
 ---
-- name: Ensure Elasticsearch key is available (Debian)
+- name: Ensure Elastic Stack key is available (Debian)
   apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
-- name: Ensure Elasticsearch apt repository is configured (Debian)
+- name: Ensure Elastic Stack apt repository is configured (Debian)
   apt_repository:
     repo: deb https://artifacts.elastic.co/packages/{{ elastic_release }}.x/apt stable main
     state: present
+  when: elastic_variant == "elastic"
+
+- name: Ensure Elastic Stack OSS apt repository is configured (Debian)
+  apt_repository:
+    repo: deb https://artifacts.elastic.co/packages/oss-{{ elastic_release }}.x/apt stable main
+    state: present
+  when: elastic_variant == "oss"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -3,7 +3,7 @@
   rpm_key:
     key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
-- name: Ensure Elasticsearch yum repository is configured (RedHat)
+- name: Ensure Elastic Stack yum repository is configured (RedHat)
   yum_repository:
     name: elastic-{{ elastic_release }}.x
     description: Elastic Release {{ elastic_release }}.x
@@ -11,3 +11,13 @@
     baseurl: https://artifacts.elastic.co/packages/{{ elastic_release }}.x/yum
     gpgcheck: yes
     gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+  when: elastic_variant == "elastic"
+- name: Ensure Elastic Stack OSS yum repository is configured (RedHat)
+  yum_repository:
+    name: elastic-oss-{{ elastic_release }}.x
+    description: Elastic OSS Release {{ elastic_release }}.x
+    file: elastic-oss-release
+    baseurl: https://artifacts.elastic.co/packages/oss-{{ elastic_release }}.x/yum
+    gpgcheck: yes
+    gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
+  when: elastic_variant == "oss"


### PR DESCRIPTION
* Introduce new "global" variable `elastic_variant` to chose which packages to use
* Add new tasks for OSS variants
* Add molecule scenario for OSS varaints
* Change `verify` to using Kibana instead of Filebeat because of different packages

Fixes #9