### PR TITLE
Feature - Enable local tests without affecting GH Actions

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -8,6 +8,9 @@ on:
       - main
   pull_request:
 
+molecule:
+  molecule-working-dir: ../../molecule-action/
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -8,9 +8,6 @@ on:
       - main
   pull_request:
 
-molecule:
-  molecule-working-dir: ../../molecule-action/
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,5 +35,7 @@ jobs:
       - name: Test with molecule
         run: |
           molecule test -s ${{ matrix.scenario }}
+        with:
+          molecule_working_dir: molecule-action/
         env:
           MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/molecule-action/default/INSTALL.rst
+++ b/molecule-action/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule-action/default/converge.yml
+++ b/molecule-action/default/converge.yml
@@ -1,0 +1,9 @@
+---
+# The workaround for arbitrarily named role directory is important because the git repo has one name and the role within it another
+# Found at: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include Elastic Repos"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule-action/default/molecule.yml
+++ b/molecule-action/default/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: elastic-repos-default-centos7
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .

--- a/molecule-action/default/prepare.yml
+++ b/molecule-action/default/prepare.yml
@@ -1,0 +1,11 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install requirements for Debian
+      ansible.builtin.apt:
+        name:
+        - gpg
+        - apt-transport-https
+        update_cache: yes
+      when: ansible_os_family == "Debian"

--- a/molecule-action/default/verify.yml
+++ b/molecule-action/default/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Install Kibana
+    ansible.builtin.package:
+      name: kibana

--- a/molecule-action/elastic8/INSTALL.rst
+++ b/molecule-action/elastic8/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule-action/elastic8/converge.yml
+++ b/molecule-action/elastic8/converge.yml
@@ -1,0 +1,11 @@
+---
+# The workaround for arbitrarily named role directory is important because the git repo has one name and the role within it another
+# Found at: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
+- name: Converge
+  vars:
+    elastic_release: 8
+  hosts: all
+  tasks:
+    - name: "Include Elastic Repos"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule-action/elastic8/molecule.yml
+++ b/molecule-action/elastic8/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: elastic-repos-default
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .

--- a/molecule-action/elastic8/prepare.yml
+++ b/molecule-action/elastic8/prepare.yml
@@ -1,0 +1,11 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install requirements for Debian
+      ansible.builtin.apt:
+        name:
+        - gpg
+        - apt-transport-https
+        update_cache: yes
+      when: ansible_os_family == "Debian"

--- a/molecule-action/elastic8/verify.yml
+++ b/molecule-action/elastic8/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Install Kibana
+    ansible.builtin.package:
+      name: kibana

--- a/molecule-action/oss/INSTALL.rst
+++ b/molecule-action/oss/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule-action/oss/converge.yml
+++ b/molecule-action/oss/converge.yml
@@ -1,0 +1,11 @@
+---
+# The workaround for arbitrarily named role directory is important because the git repo has one name and the role within it another
+# Found at: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
+- name: Converge
+  hosts: all
+  vars:
+    elastic_variant: oss
+  tasks:
+    - name: "Include Elastic Repos"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule-action/oss/molecule.yml
+++ b/molecule-action/oss/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: elastic-repos-default-oss
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .

--- a/molecule-action/oss/prepare.yml
+++ b/molecule-action/oss/prepare.yml
@@ -1,0 +1,11 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install requirements for Debian
+      ansible.builtin.apt:
+        name:
+        - gpg
+        - apt-transport-https
+        update_cache: yes
+      when: ansible_os_family == "Debian"

--- a/molecule-action/oss/verify.yml
+++ b/molecule-action/oss/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Install Kibana
+    ansible.builtin.package:
+      name: kibana-oss

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,8 +4,29 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: elastic-repos-default
+  - name: elastic-repos-default-centos7
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+  - name: elastic-repos-default-centos8
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+  - name: elastic-repos-default-debian10
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+  - name: elastic-repos-default-debian11
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
Tried to set in .github/workflow/molecule.yml a molecule-working-dir. Set it to `../../molecule-action/`.  I also created a molecule-action/ directory where the Github Action molecule test should look for the molecule.yml. 

I also added centos8, debian10, and debian11 to the local checks in molecule/. This would not be possible if the matrix distribution dictionary is defined in the Github Action. It would loop 4 times over every platform.

Unfortunately, I have no idea where I can set the molecule-working-dir in the .github/workflow/molecule.yml. So hopefully the pipeline will not fail. (Src: [https://github.com/marketplace/actions/ansible-molecule](https://github.com/marketplace/actions/ansible-molecule))

The goal is to enable local tests without affecting the Github Action checks for faster debugging.

**I'm not sure if molecule-working-dir will work**

Local molecule test passed, but I think the test didn't run the tasks:
TASK [Destroy molecule instance(s)] ********************************************
changed: [localhost] => (item=elastic-repos-default-centos7)
changed: [localhost] => (item=elastic-repos-default-centos8)
changed: [localhost] => (item=elastic-repos-default-debian10)
changed: [localhost] => (item=elastic-repos-default-debian11)

TASK [Wait for instance(s) deletion to complete] *******************************
ok: [localhost] => (item=elastic-repos-default-centos7)
ok: [localhost] => (item=elastic-repos-default-centos8)
ok: [localhost] => (item=elastic-repos-default-debian10)
ok: [localhost] => (item=elastic-repos-default-debian11)

TASK [Delete docker networks(s)] ***********************************************

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0

INFO     Pruning extra files from scenario ephemeral directory

