### PR TITLE
Update list of supported distros #27

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      # max-parallel: 4
+      max-parallel: 4
       matrix:
-        distro: [centos7, debian10, rockylinux8]
+        distro: [centos7, centos8, debian10, debian11, rockylinux8, rockylinux9, ubuntu2004, ubuntu2204]
         scenario: [default, oss, elastic8]
 
     steps:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 4
       matrix:
 
-        distro: [centos7, debian10, debian11, rockylinux8, rockylinux9, ubuntu2004, ubuntu2204]
+        distro: [centos7, debian10, debian11, rockylinux8, rockylinux9]
         scenario: [default, oss, elastic8]
 
     steps:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 4
       matrix:
 
-        distro: [centos7, centos8, debian10, debian11, rockylinux8, rockylinux9, ubuntu2004, ubuntu2204]
+        distro: [centos7, debian10, debian11, rockylinux8, rockylinux9, ubuntu2004, ubuntu2204]
         scenario: [default, oss, elastic8]
 
     steps:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     versions:
     - "7"
     - "8"
+    - "9"
   - name: Debian
     versions:
     - buster
@@ -20,10 +21,6 @@ galaxy_info:
     versions:
     - focal
     - jammy
-  - name: Rocky Linux
-    versions:
-    - "8"
-    - "9"
 
   galaxy_tags:
     - logmanagement

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,10 +17,6 @@ galaxy_info:
     versions:
     - buster
     - bullseye
-  - name: Ubuntu
-    versions:
-    - focal
-    - jammy
 
   galaxy_tags:
     - logmanagement

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,15 @@ galaxy_info:
   - name: Debian
     versions:
     - buster
+    - bullseye
+  - name: Ubuntu
+    versions:
+    - focal
+    - jammy
+  - name: Rocky Linux
+    versions:
+    - "8"
+    - "9"
 
   galaxy_tags:
     - logmanagement


### PR DESCRIPTION
```
  - name: Rocky Linux
    versions:
    - "8"
    - "9"
```
**That's in the meta/main.yml of my pull request. I think we should remove it because of the following circumstances:**

- Rocky Linux **not found** in Galaxy REST API. See [https://galaxy.ansible.com/api/v1/platforms/?search=rocky](https://galaxy.ansible.com/api/v1/platforms/?search=rocky
)
- The documentation ( src: [https://galaxy.ansible.com/docs/contributing/creating_role.html](https://galaxy.ansible.com/docs/contributing/creating_role.html) ) mentioned the following:
_"Required. Provide a list of **valid platforms, and for each platform, a list of valid versions**. The obvious question of course is, where does one find the list of valid platforms? You can find the [list of platforms here](https://galaxy.ansible.com/api/v1/platforms/). The list is paginated. Click on the next_link value to get to view the next page. It’s not the prettiest interface, but for now, it works."_

Of course, we should also remove it in .github/workflow/molecule.yml.