### PR TITLE
Workaround for GnuPG keys on Rocky Linux 9

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       # max-parallel: 4
       matrix:
-        distro: [centos7, debian10, rockylinux8]
+        distro: [centos7, debian10, rockylinux8, rockylinux9]
         scenario: [default, oss, elastic8]
 
     steps:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,5 @@
 # defaults file for elastic-repos
 elastic_release: 7
 elastic_variant: elastic
+
+elastic_rpm_workaround: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     versions:
     - "7"
     - "8"
+    - "9"
   - name: Debian
     versions:
     - buster

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,8 @@
 # Found at: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
 - name: Converge
   hosts: all
+  vars:
+    elastic_rpm_workaround: true
   tasks:
     - name: "Include Elastic Repos"
       ansible.builtin.include_role:

--- a/molecule/elastic8/converge.yml
+++ b/molecule/elastic8/converge.yml
@@ -4,6 +4,7 @@
 - name: Converge
   vars:
     elastic_release: 8
+    elastic_rpm_workaround: true
   hosts: all
   tasks:
     - name: "Include Elastic Repos"

--- a/molecule/oss/converge.yml
+++ b/molecule/oss/converge.yml
@@ -5,6 +5,7 @@
   hosts: all
   vars:
     elastic_variant: oss
+    elastic_rpm_workaround: true
   tasks:
     - name: "Include Elastic Repos"
       ansible.builtin.include_role:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -23,7 +23,7 @@
         # we can skip having idempotency checks fixed
         - name: Set Crypto policies to legacy
           ansible.builtin.command: "update-crypto-policies --set LEGACY"
-            changed_when: false
+          changed_when: false
 
       when:
         - elastic_rpm_workaround | bool

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -12,8 +12,16 @@
       when:
         - not elastic_rpm_workaround | bool
 
-    - name: Set Crypto policies to legacy
-      ansible.builtin.command: "update-crypto-policies --set LEGACY"
+    - name: Enable workaround for rpm keys
+      block:
+
+        - name: Install crypto-policies-scripts
+          ansible.builtin.package:
+            name: crypto-policies-scripts
+
+        - name: Set Crypto policies to legacy
+          ansible.builtin.command: "update-crypto-policies --set LEGACY"
+
       when:
         - elastic_rpm_workaround | bool
   when:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,8 +1,10 @@
 ---
+
 - name: Ensure Elastic repository key is available (RedHat)
   ansible.builtin.rpm_key:
     key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+
 - name: Ensure Elastic Stack yum repository is configured (RedHat)
   ansible.builtin.yum_repository:
     name: elastic-{{ elastic_release }}.x
@@ -12,6 +14,7 @@
     gpgcheck: yes
     gpgkey: https://artifacts.elastic.co/GPG-KEY-elasticsearch
   when: elastic_variant == "elastic"
+
 - name: Ensure Elastic Stack OSS yum repository is configured (RedHat)
   ansible.builtin.yum_repository:
     name: elastic-oss-{{ elastic_release }}.x

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -4,7 +4,7 @@
 # for more information why this is needed
 
 - name: Workaround for EL > 8
-  ansible.builtin.block:
+  block:
 
     - name: Show a warning
       ansible.builtin.debug:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -19,8 +19,11 @@
           ansible.builtin.package:
             name: crypto-policies-scripts
 
+        # since we don't expect to have that workaround for long
+        # we can skip having idempotency checks fixed
         - name: Set Crypto policies to legacy
           ansible.builtin.command: "update-crypto-policies --set LEGACY"
+            changed_when: false
 
       when:
         - elastic_rpm_workaround | bool

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,5 +1,24 @@
 ---
 
+# See https://github.com/elastic/elasticsearch/issues/85876
+# for more information why this is needed
+
+- name: Workaround for EL > 8
+  block:
+
+    - name: Show a warning
+      debug:
+        msg: "For this workaround to work, please set elastic_rpm_workaround to true"
+      when:
+        - not elastic_rpm_workaround | bool
+
+    - name: Set Crypto policies to legacy
+      command: "update-crypto-policies --set LEGACY"
+      when:
+        - elastic_rpm_workaround | bool
+  when:
+    - ansible_distribution_major_version >= "9"
+
 - name: Ensure Elastic repository key is available (RedHat)
   ansible.builtin.rpm_key:
     key: https://artifacts.elastic.co/GPG-KEY-elasticsearch

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -4,16 +4,16 @@
 # for more information why this is needed
 
 - name: Workaround for EL > 8
-  block:
+  ansible.builtin.block:
 
     - name: Show a warning
-      debug:
+      ansible.builtin.debug:
         msg: "For this workaround to work, please set elastic_rpm_workaround to true"
       when:
         - not elastic_rpm_workaround | bool
 
     - name: Set Crypto policies to legacy
-      command: "update-crypto-policies --set LEGACY"
+      ansible.builtin.command: "update-crypto-policies --set LEGACY"
       when:
         - elastic_rpm_workaround | bool
   when:


### PR DESCRIPTION
There's an issue with the Elastic GnuPG key and modern Linux distributions. We need to set a workaround until this is fixed.

See https://github.com/elastic/elasticsearch/issues/85876 for details.

fixes #30 