### PR TITLE
Feature Ubuntu 20.04 and 22.04 hosts

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 4
       matrix:
 
-        distro: [centos7, debian10, debian11, rockylinux8, rockylinux9]
+        distro: [centos7, debian10, debian11, rockylinux8, rockylinux9, ubuntu2004, ubuntu2204]
         scenario: [default, oss, elastic8]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You need `gpg` to be installed because packages / repositories are digitally sig
 
 Debian and Ubuntu hosts need to have `apt-transport-https` installed to deal with Elastics repositories.
 
+Ubuntu hosts also need to have `gpg-agent` installed.
+
 Role Variables
 --------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,10 @@ galaxy_info:
     versions:
     - buster
     - bullseye
+  - name: Ubuntu
+    versions:
+    - focal
+    - jammy
 
   galaxy_tags:
     - logmanagement

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -9,3 +9,9 @@
         - apt-transport-https
         update_cache: yes
       when: ansible_os_family == "Debian"
+    - name: Install requirements for Ubuntu
+      ansible.builtin.apt:
+        name:
+        - gpg-agent
+        update_cache: yes
+      when: ansible_os_family == "Debian" and ansible_distribution == "Ubuntu"

--- a/molecule/elastic8/prepare.yml
+++ b/molecule/elastic8/prepare.yml
@@ -9,3 +9,9 @@
         - apt-transport-https
         update_cache: yes
       when: ansible_os_family == "Debian"
+    - name: Install requirements for Ubuntu
+      ansible.builtin.apt:
+        name:
+        - gpg-agent
+        update_cache: yes
+      when: ansible_os_family == "Debian" and ansible_distribution == "Ubuntu"

--- a/molecule/oss/prepare.yml
+++ b/molecule/oss/prepare.yml
@@ -9,3 +9,9 @@
         - apt-transport-https
         update_cache: yes
       when: ansible_os_family == "Debian"
+    - name: Install requirements for Ubuntu
+      ansible.builtin.apt:
+        name:
+        - gpg-agent
+        update_cache: yes
+      when: ansible_os_family == "Debian" and ansible_distribution == "Ubuntu"


### PR DESCRIPTION
Ubuntu needs to have gpg-agent installed, or else the role will fail. There are no additional changes required to the debian.yml or to add an extra task playlist like ubuntu.yml.

**Changes:**
- Added platform and versions for supported Ubuntu distributions in meta/main.yml
- Added in prepare.yml in all scenarios the requirement that gpg-agent has to be installed if it is an Ubuntu host
- Added geerlinguy's Docker Images to GitHub workflow for molecule tests
- Changed README.md because gpg-agent is required to handle signing

**Error Message without gpg-agent installed**
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "cmd": "/usr/bin/apt-key add -",
    "invocation": {
        "module_args": {
            "data": null,
            "file": null,
            "id": null,
            "key": null,
            "keyring": null,
            "keyserver": null,
            "state": "present",
            "url": "https://artifacts.elastic.co/GPG-KEY-elasticsearch",
            "validate_certs": true
        }
    },
    "msg": "Unable to add a key from binary data",
    "rc": 2,
    "stderr": "Warning: apt-key output should not be parsed (stdout is not a terminal)\ngpg: failed to start agent '/usr/bin/gpg-agent': No such file or directory\ngpg: can't connect to the agent: No such file or directory\n",
    "stderr_lines": [
        "Warning: apt-key output should not be parsed (stdout is not a terminal)",
        "gpg: failed to start agent '/usr/bin/gpg-agent': No such file or directory",
        "gpg: can't connect to the agent: No such file or directory"
    ],
    "stdout": "",
    "stdout_lines": []
}
```